### PR TITLE
Add the user defined class prefix at the widget root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fixes missing root widget class when `classPrefix` option is set.
+
 ## 1.0.1 (2022-08-03)
 
 ### Fixes

--- a/modules/@apostrophecms/form-widget/views/widget.html
+++ b/modules/@apostrophecms/form-widget/views/widget.html
@@ -5,7 +5,7 @@
 {% set recaptchaSite = apos.modules['@apostrophecms/form'].options.recaptchaSite or (data.global.useRecaptcha and data.global.recaptchaSite) %}
 {% set recaptchaReady = form.enableRecaptcha and recaptchaSite %}
 
-<div data-apos-form-wrapper>
+<div class="{{ prependIfPrefix('') }}" data-apos-form-wrapper>
 {% if form %}
   {% set params = false %}
   {% if form.queryParamList %}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

If a developer chooses to use the CSS class prefix, let's say `my-form`, the module will create correctly classes like `my-form__form`, `my-form__submit`, etc. However it won't set `my-form` at the widget root wrapper as required by the BEM standard. This PR fixes this. 

## What are the specific steps to test this change?

When I set the `classPrefix` to `my-form` and add a form widget to the page, the widget wrapper should have class `my-form`.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

