### PR TITLE
only one form in form widget relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This can now be disabled.
 
 ### Fixes
 
-* We can now select only one form when editing the form widget relationship to form field ('Form to display').
+* To avoid confusion, we can now select only one form when editing the form widget relationship to form field ('Form to display'). Note that selecting more than one form never had any useful effect.
 
 ## 1.1.1 (2023-02-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ We use the default express connect-multiparty size limits. The rule is checked b
 This can now be disabled.
 * Add divider widget (`<hr>` tag) to form widgets.
 
+### Fixes
+
+* We can now select only one form when editing the form widget relationship to form field ('Form to display').
+
 ## 1.1.1 (2023-02-17)
 
 ### Fixes

--- a/modules/@apostrophecms/form-widget/index.js
+++ b/modules/@apostrophecms/form-widget/index.js
@@ -13,7 +13,8 @@ module.exports = {
         label: 'aposForm:widgetFormSelect',
         type: 'relationship',
         withType: '@apostrophecms/form',
-        required: true
+        required: true,
+        max: 1
       }
     }
   },

--- a/modules/@apostrophecms/form-widget/ui/src/index.js
+++ b/modules/@apostrophecms/form-widget/ui/src/index.js
@@ -73,6 +73,7 @@ export default () => {
           try {
             input.recaptcha = await recaptcha.getToken(el);
           } catch (error) {
+            // eslint-disable-next-line
             console.error('reCAPTCHA execution error:', error);
             apos.util.addClass(recaptchaError, 'apos-form-visible');
             return null;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Set the form widget `_form` relationship `max` to 1

## What are the specific steps to test this change?

1. You can no longer select multiple forms when editing the form widget relationship

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
