### PR TITLE
fix missing select icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add group widget which is a fieldset container for other form widgets.
 
+### Fixes
+
+* Fix missing select widget icon.
+
 ## 1.2.0 (2023-10-12)
 
 ### Adds

--- a/modules/@apostrophecms/form-widget/index.js
+++ b/modules/@apostrophecms/form-widget/index.js
@@ -2,10 +2,10 @@ module.exports = {
   extend: '@apostrophecms/widget-type',
   options: {
     label: 'aposForm:widgetForm',
-    icon: 'format-select-icon'
+    icon: 'form-select-icon'
   },
   icons: {
-    'format-select-icon': 'FormSelect'
+    'form-select-icon': 'FormSelect'
   },
   fields: {
     add: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add missing form select widget icon

## What are the specific steps to test this change?

⚠️ the icons are displayed only in the editor modal

1. Open the widget editor modal
2. When you click on the `Add Content` button you must see an icon for the select widget

If you see the following it's a failure
![widgets](https://github.com/apostrophecms/form/assets/1765606/b949f0ef-8d1c-44e5-97eb-0597160529b6)

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
