### PR TITLE
Pro 5899 boolean fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Changes
 
- * Updates the documentation. No code changes.
+ * Updates the documentation.
+
+### Fixes
+* Changes the value collection for the `form-boolean-field-widget` to the `checked` status instead of the `value` directly.
 
 ## 1.3.0 (2023-11-03)
 

--- a/modules/@apostrophecms/form-boolean-field-widget/ui/src/index.js
+++ b/modules/@apostrophecms/form-boolean-field-widget/ui/src/index.js
@@ -37,7 +37,7 @@ export default () => {
 
       return {
         field: input.getAttribute('name'),
-        value: input.value
+        value: input.checked
       };
     }
   };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR changes the way the `form-boolean-field-widget` returns the field value. In the past it always returned a value of `true`. Now it correctly returns the `checked` status of the input. Closes PRO-5899.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly
1. Create a form with a boolean field.
2. Confirm that upon submission a document with the correct value for the field is stored in the `aposFormsSubmissions` collection.
## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
